### PR TITLE
add no-std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@
 //! const C2: Decimal = dec!(-0.123_456);
 //! ```
 
+#![no_std]
+
 pub use fixed_macro_impl::fixed;
 
 /// Macros allowing to create constants for each available fixed-point type.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,5 +1,7 @@
 //! Macros allowing to create constants for each available fixed-point type.
 
+#![no_std]
+
 // 8-bit signed
 #[macro_export]
 /// Macro to create [I8F0](https://docs.rs/fixed/latest/fixed/types/type.I0F8.html) constants.


### PR DESCRIPTION
From what I can tell this macro can run in no-std environments (it compiles in `#![no_std]` for me). Can we add `#![no_std]` to the lib?